### PR TITLE
Update convertToDual1Character to not delete non-Serbian characters

### DIFF
--- a/src/weka/core/stemmers/KeseljSipkaStemmer.java
+++ b/src/weka/core/stemmers/KeseljSipkaStemmer.java
@@ -199,6 +199,6 @@ public abstract class KeseljSipkaStemmer extends SerbianStemmer  {
             case 'ш': return "sx";                         
             case 'Ш': return "Sy";         
         }
-     return "";   
+     return Character.toString(ch);
 	}
 }

--- a/src/weka/core/stemmers/MilosevicStemmer.java
+++ b/src/weka/core/stemmers/MilosevicStemmer.java
@@ -271,7 +271,7 @@ public class MilosevicStemmer extends SerbianStemmer {
             case 'Ш': return "Sy";   
             
         }
-     return "";   
+     return Character.toString(ch);
 }
 	
 	/**


### PR DESCRIPTION
Allow non-Serbian Latin & Cyrillic, as well as other scripts (e.g.,
Arabic, Armenian, Chinese, Devanagari, Greek, Hebrew, Japanese,
Korean, etc.) to pass through unchanged.